### PR TITLE
Update .gitignore to ignore .env files

### DIFF
--- a/starter-frontend/.gitignore
+++ b/starter-frontend/.gitignore
@@ -18,3 +18,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environmental Variables
+*.env
+*.env.example
+*.env.staging


### PR DESCRIPTION
Added .env files to .gitignore in starter-frontend! (Honestly, if they're used in client-side code it'd be leaked anyways, but generally committing .env files isn't good practice and this serves as a reminder at minimum).